### PR TITLE
Destroy previously existing proxy on computed property get

### DIFF
--- a/tests/unit/property-test.js
+++ b/tests/unit/property-test.js
@@ -39,3 +39,37 @@ test('property has definition meta', function(assert) {
   let instanceDef = getDefinition(owner, 'doc');
   assert.equal(instanceDef.database, 'db');
 });
+
+test('property destroys previous proxy on database change', function(assert) {
+  let Owner = Ember.Object.extend({
+    id: 'duck',
+    doc: docById({ database: 'db', id: 'id' })
+  });
+
+  let owner = Owner.create({ db: this.db });
+
+  let first = owner.get('doc');
+  owner.set('db', this.store.database('another'));
+  let second = run(() => owner.get('doc'));
+
+  assert.ok(second._internal);
+
+  assert.ok(first !== second);
+  assert.ok(first.isDestroying);
+});
+
+test('property does not recreate proxy on same database set', function(assert) {
+  let Owner = Ember.Object.extend({
+    id: 'duck',
+    doc: docById({ database: 'db', id: 'id' })
+  });
+
+  let owner = Owner.create({ db: this.db });
+
+  let first = owner.get('doc');
+  owner.set('db', this.db);
+  let second = owner.get('doc');
+
+  assert.ok(first === second);
+  assert.ok(!first.isDestroying);
+});


### PR DESCRIPTION
also don't assert missing get(this, opts.database)